### PR TITLE
Bayonet and Thrown Weapon Updates

### DIFF
--- a/Assets/Prefabs/Actors/Soldier-Bayonet.prefab
+++ b/Assets/Prefabs/Actors/Soldier-Bayonet.prefab
@@ -1562,7 +1562,7 @@ MonoBehaviour:
     m_EventID: 977896394
   - m_Destination: {fileID: 11444962}
     m_EventID: 362682009
-  m_CachedInstanceID: 11342
+  m_CachedInstanceID: 11202
   m_Description: 
   m_IgnoreTimeScale: 0
   m_ResetStatusOnDisable: 1
@@ -1678,7 +1678,7 @@ MonoBehaviour:
   m_Transitions:
   - m_Destination: {fileID: 11479614}
     m_EventID: 1997708586
-  m_CachedInstanceID: 11340
+  m_CachedInstanceID: 11200
   m_Description: 
   m_IgnoreTimeScale: 0
   m_ResetStatusOnDisable: 1
@@ -1780,12 +1780,12 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   attackType: 2
-  attackSize: {x: 2, y: 1}
-  attackOffset: {x: 1.5, y: 0}
+  attackSize: {x: 4, y: 0.6}
+  attackOffset: {x: 1.5, y: 0.7}
   heldOffset: {x: -0.5, y: -0.013, z: -0.113}
   heldOrientation: {x: 35, y: 350, z: 198}
-  lightDamage: 20
-  heavyDamage: 40
+  lightDamage: 10
+  heavyDamage: 15
 --- !u!114 &11462540
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -1840,7 +1840,7 @@ MonoBehaviour:
   m_HideScript: 1
   m_Position: {x: 0, y: 0}
   m_Transitions: []
-  m_CachedInstanceID: 11330
+  m_CachedInstanceID: 11190
   m_Description: 
   m_EnabledState: {fileID: 0}
   m_LastEnabledState: {fileID: 0}
@@ -1867,7 +1867,7 @@ MonoBehaviour:
   m_Transitions:
   - m_Destination: {fileID: 11479614}
     m_EventID: 1997708586
-  m_CachedInstanceID: 11338
+  m_CachedInstanceID: 11198
   m_Description: 
   m_IgnoreTimeScale: 0
   m_ResetStatusOnDisable: 1
@@ -2033,7 +2033,7 @@ MonoBehaviour:
     m_EventID: 977896394
   - m_Destination: {fileID: 11492368}
     m_EventID: 1901486430
-  m_CachedInstanceID: 11336
+  m_CachedInstanceID: 11196
   m_Description: 
   m_IgnoreTimeScale: 0
   m_ResetStatusOnDisable: 1
@@ -2102,7 +2102,7 @@ MonoBehaviour:
   m_Transitions:
   - m_Destination: {fileID: 11479614}
     m_EventID: 1997708586
-  m_CachedInstanceID: 11334
+  m_CachedInstanceID: 11194
   m_Description: 
   m_IgnoreTimeScale: 0
   m_ResetStatusOnDisable: 1
@@ -2195,7 +2195,7 @@ MonoBehaviour:
     m_EventID: 734815261
   - m_Destination: {fileID: 11444962}
     m_EventID: 362682009
-  m_CachedInstanceID: 11344
+  m_CachedInstanceID: 11204
   m_Description: 
   m_IgnoreTimeScale: 0
   m_ResetStatusOnDisable: 1
@@ -3158,6 +3158,26 @@ Prefab:
       propertyPath: bloodMelee
       value: 
       objectReference: {fileID: 145470, guid: 0ca7678bdd3567541b86f1a64ef76496, type: 2}
+    - target: {fileID: 0}
+      propertyPath: attackSize.x
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: attackOffset.y
+      value: 0.7
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: lightDamage
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: heavyDamage
+      value: 15
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: attackSize.y
+      value: 0.6
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 0}
   m_RootGameObject: {fileID: 188124}

--- a/Assets/Prefabs/Weapons/Bayonet.prefab
+++ b/Assets/Prefabs/Weapons/Bayonet.prefab
@@ -310,12 +310,12 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   attackType: 2
-  attackSize: {x: 2, y: 1}
-  attackOffset: {x: 1.5, y: 0}
+  attackSize: {x: 4.5, y: 1.5}
+  attackOffset: {x: 1.5, y: 1.5}
   heldOffset: {x: -0.5, y: -0.013, z: -0.113}
   heldOrientation: {x: 35, y: 350, z: 198}
-  lightDamage: 4
-  heavyDamage: 7
+  lightDamage: 2
+  heavyDamage: 4
 --- !u!114 &11497070
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -339,11 +339,11 @@ Prefab:
     m_Modifications:
     - target: {fileID: 0}
       propertyPath: lightDamage
-      value: 4
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 0}
       propertyPath: heavyDamage
-      value: 7
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 0}
       propertyPath: m_Layer
@@ -356,6 +356,22 @@ Prefab:
     - target: {fileID: 0}
       propertyPath: m_Enabled
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: attackOffset.x
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: attackSize.x
+      value: 4.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: attackSize.y
+      value: 1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: attackOffset.y
+      value: 1.5
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 0}

--- a/Assets/Prefabs/Weapons/Musket.prefab
+++ b/Assets/Prefabs/Weapons/Musket.prefab
@@ -309,6 +309,10 @@ Prefab:
       propertyPath: m_Enabled
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: attackOffset.y
+      value: 10
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 0}
   m_RootGameObject: {fileID: 155526}

--- a/Assets/Prefabs/Weapons/PerkContainer.prefab
+++ b/Assets/Prefabs/Weapons/PerkContainer.prefab
@@ -165,6 +165,7 @@ GameObject:
   serializedVersion: 4
   m_Component:
   - 4: {fileID: 433338}
+  - 114: {fileID: 11400738}
   m_Layer: 0
   m_Name: PerkContainer
   m_TagString: Untagged
@@ -629,6 +630,17 @@ BoxCollider2D:
   m_Offset: {x: 0.03, y: 0.5}
   serializedVersion: 2
   m_Size: {x: 5, y: 1}
+--- !u!114 &11400738
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 189190}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6e95f1c93198a4c4fbeac826e3da27c0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &11403018
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -713,7 +725,7 @@ MonoBehaviour:
   heldOrientation: {x: 36, y: 340, z: 146}
   lightDamage: 4
   heavyDamage: 7
-  throwDamage: 10
+  throwDamage: 7
 --- !u!114 &11425814
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -746,7 +758,7 @@ MonoBehaviour:
   heldOrientation: {x: 36, y: 340, z: 146}
   lightDamage: 4
   heavyDamage: 7
-  throwDamage: 10
+  throwDamage: 6
 --- !u!114 &11445532
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -779,7 +791,7 @@ MonoBehaviour:
   heldOrientation: {x: 33.7, y: 202, z: 23}
   lightDamage: 20
   heavyDamage: 20
-  throwDamage: 5
+  throwDamage: 0
 --- !u!114 &11476048
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/Assets/Prefabs/Weapons/PerkContainer.prefab
+++ b/Assets/Prefabs/Weapons/PerkContainer.prefab
@@ -791,7 +791,7 @@ MonoBehaviour:
   heldOrientation: {x: 33.7, y: 202, z: 23}
   lightDamage: 20
   heavyDamage: 20
-  throwDamage: 0
+  throwDamage: 10
 --- !u!114 &11476048
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/Assets/Scripts/Combat/Projectile.cs
+++ b/Assets/Scripts/Combat/Projectile.cs
@@ -17,7 +17,8 @@ public class Projectile : MonoBehaviour
     private BaseCollision _collision;
     private float _startXPos;
     private float _endXPos;
-    private int _damage;
+	private int _damage;
+    private int _throwDamage;
     private int _distance;
     private Transform _child;
 
@@ -57,22 +58,22 @@ public class Projectile : MonoBehaviour
         if (collider.GetComponent<Damage>())
         {
             _distance = Math.Abs((int)(_startXPos - _endXPos));
-            _damage = _damage - (_distance / 2);
-            if (_damage < 0)
-                _damage = 0;
-            Debug.Log("Projectile Damge: " + _damage);
-            collider.GetComponent<Damage>().ExecuteDamage(_damage, collider);
+            _throwDamage = 10 - (_distance / 2);
+            if (_throwDamage < 0)
+                _throwDamage = 0;
+			Debug.Log("Projectile Damge: " + (_damage + _throwDamage));
+			collider.GetComponent<Damage>().ExecuteDamage( (_throwDamage + _damage), collider);
         }
     }
 
-    public void StartProjectile(float damage, float velocity = 25)
+	public void StartProjectile(float velocity = 25, int baseDamage = 0)
     {
-        _damage = (int)damage;
         if (state == State.InAir)
             return;
-
+		
         _startXPos = transform.position.x;
-        state = State.InAir;
+		_damage = baseDamage;
+		state = State.InAir;
         sign = Mathf.Sign(velocity);
         this.velocity = Mathf.Abs(velocity);
         enabled = true;

--- a/Assets/Scripts/Combat/Throw.cs
+++ b/Assets/Scripts/Combat/Throw.cs
@@ -51,9 +51,8 @@ public class Throw : MonoBehaviour
         _attack.weapon.transform.localScale = Vector3.one;
         _attack.weapon.transform.position = transform.position;
         _attack.weapon.GetComponent<BoxCollider2D>().enabled = true;
-        Debug.Log(GetComponent<Attack>().weapon.throwDamage);
-        _attack.weapon.GetOrAddComponent<Projectile>().StartProjectile(GetComponent<Attack>().weapon.throwDamage,
-            _movement.direction == Movement.Direction.Left ? -velocity : velocity);
+        _attack.weapon.GetOrAddComponent<Projectile>().StartProjectile(
+			_movement.direction == Movement.Direction.Left ? -velocity : velocity, (int)(_attack.weapon.throwDamage) );
         SetState(State.Perform);
         _attack.weapon.transform.rotation = Quaternion.identity;
         _attack.weapon.gameObject.layer = LayerMask.NameToLayer("Items");

--- a/Assets/Scripts/Combat/Weapon.cs
+++ b/Assets/Scripts/Combat/Weapon.cs
@@ -11,5 +11,5 @@ public class Weapon : MonoBehaviour
     public Vector3 heldOrientation = Vector3.zero;
     public float lightDamage = 10;
     public float heavyDamage = 15;
-    public float throwDamage = 10;
+	public float throwDamage = 0;
 }


### PR DESCRIPTION
- Update Bayonet weapon to have a wider hitbox
- Update Bayonet weapon to have reduced damage on Light and Heavy Attack
- Update Weapon script to include a variable for Throw damage (replaces damage as distance 
    calculation damage value) 
- Weapon's throw damage value now summed with calculated throw damage
- Added Throw damage value of 7 to Axe (with above, raises thrown axe
  damage)
