### PR TITLE
Fix/correct background scaling

### DIFF
--- a/Assets/Prefabs/Util/World.prefab
+++ b/Assets/Prefabs/Util/World.prefab
@@ -566,12 +566,12 @@ MonoBehaviour:
   terrain: {fileID: 127990, guid: adf920ea3adcf61499ef430d5f5cbab4, type: 2}
   enemies:
   - {fileID: 188124, guid: f7cc6c9782046944c9737c3bc517099c, type: 2}
-  - {fileID: 188124, guid: 3902e28db3726314f96ae48a242ffafc, type: 2}
+  - {fileID: 177166, guid: e0eb5448c85624fbea3f7cfd45773ca0, type: 2}
   - {fileID: 180872, guid: 649c1ce1c5214ba4db47ea48e81742ae, type: 2}
   - {fileID: 188124, guid: 78346bbcfd956f34ba4d56aae30565e7, type: 2}
   props:
-  - {fileID: 127602, guid: ddd4c3ec236339342a41b55ddc0cd76b, type: 2}
-  - {fileID: 124166, guid: ae79f3def7a20c44eb9ac81db6e51333, type: 2}
+  - {fileID: 0}
+  - {fileID: 0}
   decals:
   - {fileID: 126218, guid: 1bb39e4b7c7d6c142a7d9f82f77c67f3, type: 2}
   items:
@@ -584,8 +584,6 @@ MonoBehaviour:
   propDensity: 3
   decalDensity: 10
   itemDensity: 1
-  screensBeforeSecondEnemy: 2
-  screensBeforeBoss: 4
 --- !u!1001 &100100000
 Prefab:
   m_ObjectHideFlags: 1

--- a/Assets/Scenes/PlayScene.unity
+++ b/Assets/Scenes/PlayScene.unity
@@ -763,6 +763,10 @@ Prefab:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 2395648, guid: fbc55672ab8bf9b49bd155021bb1d123, type: 2}
+      propertyPath: m_Materials.Array.size
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 470634, guid: fbc55672ab8bf9b49bd155021bb1d123, type: 2}
       propertyPath: m_LocalPosition.x
       value: -3.0745623
@@ -803,6 +807,10 @@ Prefab:
       propertyPath: enemies.Array.data[1]
       value: 
       objectReference: {fileID: 177166, guid: e0eb5448c85624fbea3f7cfd45773ca0, type: 2}
+    - target: {fileID: 2395648, guid: fbc55672ab8bf9b49bd155021bb1d123, type: 2}
+      propertyPath: m_Materials.Array.data[1]
+      value: 
+      objectReference: {fileID: 2100000, guid: 3e55d1416e5d141d18e46cf976753ac2, type: 2}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: fbc55672ab8bf9b49bd155021bb1d123, type: 2}
   m_IsPrefabParent: 0

--- a/Assets/Scripts/World/ScrollingBackground.cs
+++ b/Assets/Scripts/World/ScrollingBackground.cs
@@ -47,8 +47,8 @@ public class ScrollingBackground : MonoBehaviour
         {
             //Calculate how far backward or forward along the x-axis the texture should move
             // Basically new-x = old-x + (scrollSpeed * (cameraspeed scaled with deltatime))
-            float step = (scrollSpeed * (cameraFollow.velocity.x * Time.deltaTime)) * directionScalar;
-            float x = Mathf.Repeat(renderer.material.mainTextureOffset.x + step, 1);
+            float step = (scrollSpeed * (cameraFollow.velocity.x * Time.deltaTime)) * directionScalar * renderer.material.mainTextureScale.x;
+            float x = Mathf.Repeat(renderer.material.mainTextureOffset.x  + step, 1) ;
 
             Vector2 offset = new Vector2(x, savedOffset.y);
             renderer.material.mainTextureOffset = offset;

--- a/Assets/Sprites/Images/Forest/Backgrounds/Near/Short.png.meta
+++ b/Assets/Sprites/Images/Forest/Backgrounds/Near/Short.png.meta
@@ -32,13 +32,13 @@ TextureImporter:
     filterMode: -1
     aniso: 16
     mipBias: -1
-    wrapMode: 1
-  nPOTScale: 0
+    wrapMode: 0
+  nPOTScale: 1
   lightmap: 0
   rGBM: 0
   compressionQuality: 50
   allowsAlphaSplitting: 0
-  spriteMode: 1
+  spriteMode: 0
   spriteExtrude: 1
   spriteMeshType: 1
   alignment: 0
@@ -46,7 +46,7 @@ TextureImporter:
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spritePixelsToUnits: 100
   alphaIsTransparency: 1
-  textureType: 8
+  textureType: 0
   buildTargetSettings: []
   spriteSheet:
     sprites: []

--- a/Assets/Sprites/Images/Materials/AlphaChannelShadowTemplateAngled.mat
+++ b/Assets/Sprites/Images/Materials/AlphaChannelShadowTemplateAngled.mat
@@ -19,8 +19,8 @@ Material:
         first:
           name: _MainTex
         second:
-          m_Texture: {fileID: 2800000, guid: e9e93218f8fd56948880bf27d57b44a8, type: 3}
-          m_Scale: {x: 1, y: 1}
+          m_Texture: {fileID: 2800000, guid: d581c8f7471a34ebd88d5b46bd26a0d5, type: 3}
+          m_Scale: {x: 0.45, y: 1}
           m_Offset: {x: 0, y: 0}
       data:
         first:
@@ -32,6 +32,13 @@ Material:
       data:
         first:
           name: _DetailNormalMap
+        second:
+          m_Texture: {fileID: 0}
+          m_Scale: {x: 1, y: 1}
+          m_Offset: {x: 0, y: 0}
+      data:
+        first:
+          name: _MetallicGlossMap
         second:
           m_Texture: {fileID: 0}
           m_Scale: {x: 1, y: 1}
@@ -71,13 +78,6 @@ Material:
           m_Texture: {fileID: 0}
           m_Scale: {x: 1, y: 1}
           m_Offset: {x: 0, y: 0}
-      data:
-        first:
-          name: _MetallicGlossMap
-        second:
-          m_Texture: {fileID: 0}
-          m_Scale: {x: 1, y: 1}
-          m_Offset: {x: 0, y: 0}
     m_Floats:
       data:
         first:
@@ -93,10 +93,6 @@ Material:
         second: 0.5
       data:
         first:
-          name: _Parallax
-        second: 0.02
-      data:
-        first:
           name: _ZWrite
         second: 1
       data:
@@ -105,8 +101,16 @@ Material:
         second: 0.5
       data:
         first:
+          name: _Metallic
+        second: 0
+      data:
+        first:
           name: _BumpScale
         second: 1
+      data:
+        first:
+          name: _Parallax
+        second: 0.02
       data:
         first:
           name: _OcclusionStrength
@@ -122,10 +126,6 @@ Material:
       data:
         first:
           name: _Mode
-        second: 0
-      data:
-        first:
-          name: _Metallic
         second: 0
     m_Colors:
       data:

--- a/Assets/Sprites/Images/Materials/backgroundForestFarTemplate4.mat
+++ b/Assets/Sprites/Images/Materials/backgroundForestFarTemplate4.mat
@@ -7,10 +7,10 @@ Material:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_Name: backgroundForestFarTemplate4
-  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_Shader: {fileID: 10752, guid: 0000000000000000f000000000000000, type: 0}
   m_ShaderKeywords: 
   m_LightmapFlags: 5
-  m_CustomRenderQueue: -1
+  m_CustomRenderQueue: 2000
   stringTagMap: {}
   m_SavedProperties:
     serializedVersion: 2
@@ -20,7 +20,7 @@ Material:
           name: _MainTex
         second:
           m_Texture: {fileID: 2800000, guid: 6bba20aaa28a14705a4d623efbdc8a9a, type: 3}
-          m_Scale: {x: 1, y: 1}
+          m_Scale: {x: 0.4, y: 1}
           m_Offset: {x: 0, y: 0}
       data:
         first:
@@ -32,6 +32,13 @@ Material:
       data:
         first:
           name: _DetailNormalMap
+        second:
+          m_Texture: {fileID: 0}
+          m_Scale: {x: 1, y: 1}
+          m_Offset: {x: 0, y: 0}
+      data:
+        first:
+          name: _MetallicGlossMap
         second:
           m_Texture: {fileID: 0}
           m_Scale: {x: 1, y: 1}
@@ -71,13 +78,6 @@ Material:
           m_Texture: {fileID: 0}
           m_Scale: {x: 1, y: 1}
           m_Offset: {x: 0, y: 0}
-      data:
-        first:
-          name: _MetallicGlossMap
-        second:
-          m_Texture: {fileID: 0}
-          m_Scale: {x: 1, y: 1}
-          m_Offset: {x: 0, y: 0}
     m_Floats:
       data:
         first:
@@ -93,10 +93,6 @@ Material:
         second: 0.5
       data:
         first:
-          name: _Parallax
-        second: 0.02
-      data:
-        first:
           name: _ZWrite
         second: 1
       data:
@@ -105,8 +101,16 @@ Material:
         second: 0.5
       data:
         first:
+          name: _Metallic
+        second: 0
+      data:
+        first:
           name: _BumpScale
         second: 1
+      data:
+        first:
+          name: _Parallax
+        second: 0.02
       data:
         first:
           name: _OcclusionStrength
@@ -122,10 +126,6 @@ Material:
       data:
         first:
           name: _Mode
-        second: 0
-      data:
-        first:
-          name: _Metallic
         second: 0
     m_Colors:
       data:

--- a/Assets/Sprites/Images/PixelizingExperiments/Materials/backgroundForestTopTemplate2Level5.mat
+++ b/Assets/Sprites/Images/PixelizingExperiments/Materials/backgroundForestTopTemplate2Level5.mat
@@ -19,8 +19,8 @@ Material:
         first:
           name: _MainTex
         second:
-          m_Texture: {fileID: 2800000, guid: 74c811cee2b31ad4e9b5e8eb476182d8, type: 3}
-          m_Scale: {x: 1, y: 1}
+          m_Texture: {fileID: 2800000, guid: 9ec9c1f1b227f4dd89c85baa1ea16b73, type: 3}
+          m_Scale: {x: 0.45, y: 1}
           m_Offset: {x: 0, y: 0}
       data:
         first:
@@ -32,6 +32,13 @@ Material:
       data:
         first:
           name: _DetailNormalMap
+        second:
+          m_Texture: {fileID: 0}
+          m_Scale: {x: 1, y: 1}
+          m_Offset: {x: 0, y: 0}
+      data:
+        first:
+          name: _MetallicGlossMap
         second:
           m_Texture: {fileID: 0}
           m_Scale: {x: 1, y: 1}
@@ -71,13 +78,6 @@ Material:
           m_Texture: {fileID: 0}
           m_Scale: {x: 1, y: 1}
           m_Offset: {x: 0, y: 0}
-      data:
-        first:
-          name: _MetallicGlossMap
-        second:
-          m_Texture: {fileID: 0}
-          m_Scale: {x: 1, y: 1}
-          m_Offset: {x: 0, y: 0}
     m_Floats:
       data:
         first:
@@ -93,10 +93,6 @@ Material:
         second: 0.5
       data:
         first:
-          name: _Parallax
-        second: 0.02
-      data:
-        first:
           name: _ZWrite
         second: 1
       data:
@@ -105,8 +101,16 @@ Material:
         second: 0.5
       data:
         first:
+          name: _Metallic
+        second: 0
+      data:
+        first:
           name: _BumpScale
         second: 1
+      data:
+        first:
+          name: _Parallax
+        second: 0.02
       data:
         first:
           name: _OcclusionStrength
@@ -122,10 +126,6 @@ Material:
       data:
         first:
           name: _Mode
-        second: 0
-      data:
-        first:
-          name: _Metallic
         second: 0
     m_Colors:
       data:


### PR DESCRIPTION
- Update tiling values for Background materials to reduce thinning of textures.
- Update ScrollingBackground script to account for tiling settings when calculating steps.
- Update Background texture sprite metadata as appropriate for backgrounds
