### PR TITLE
fix/boss-music-adjust-to-new-level-numbers 

### DIFF
--- a/Assets/Scripts/Character/Boss.cs
+++ b/Assets/Scripts/Character/Boss.cs
@@ -25,11 +25,11 @@ public class Boss : MonoBehaviour
 			_cameraFollow.lockRightEdge = true;
 			GameObject.Find("UI").GetComponent<UIManager>().bossHealthUI.enabled = true;
 
-            if (_levelManager.currentScene == 1)
+            if (_levelManager.currentScene == 0)
                 MusicPlayer.Play("Forest Boss");
-            else if (_levelManager.currentScene == 2)
+            else if (_levelManager.currentScene == 1)
                 MusicPlayer.Play("Battlefield Boss");
-            else if (_levelManager.currentScene == 3)
+            else if (_levelManager.currentScene == 2)
                 MusicPlayer.Play("Ballroom Boss Intro", "Ballroom Boss Loop");
         }
     }


### PR DESCRIPTION
Changes boss music to be triggered on scenes 0,1,2 instead of 1,2,3.
