### PR TITLE
fix/orientation-of-melee-bayonet 

### DIFF
--- a/Assets/Scripts/Character/AI/SwitchToMelee.cs
+++ b/Assets/Scripts/Character/AI/SwitchToMelee.cs
@@ -14,7 +14,9 @@ public class SwitchToMelee : ConditionNode {
 		musket = self.GetComponent<Transform> ().FindContainsInChildren ("Musket");
 		musket.GetComponent<Weapon>().attackType = Weapon.AttackType.Jab;
 		attack.SetWeapon (musket.GetComponent<Weapon> ());
-	}
+        musket.transform.localPosition = new Vector3(0.136f, -0.282f, -.0297f);
+        musket.transform.localEulerAngles = new Vector3(6.693f, 193.124f, 23.518f);
+    }
 	
 	// Update is called once per frame
 	public override Status Update () {


### PR DESCRIPTION
Fixes the rotation of the melee bayonet/musket on riflemen
