### PR TITLE
fix/dying-during-cutscene

### DIFF
--- a/Assets/Scripts/Character/PlayerHealth.cs
+++ b/Assets/Scripts/Character/PlayerHealth.cs
@@ -36,6 +36,16 @@ public class PlayerHealth : Health
 		}
     }
 
+    public void RefillForCutscene()
+    {
+        // Add 100 to Abe's health to make sure it's refilled
+        Increase(100);
+
+        // Empty the DT then add 100 to make sure it matches the health
+        damageThreshold = 0;
+        IncreaseDT(100);
+    }
+
 	public void Initialize()
 	{
 		_gameManager = GameObject.Find("GameManager").GetComponent<GameManager>();
@@ -48,7 +58,6 @@ public class PlayerHealth : Health
 		GetComponent<PlayerControls>().enabled = true;
         _animator = GetComponent<Animator>();
         _characterState = GetComponent<CharacterState>();
-
     }
 
     public override void Increase(int amount)

--- a/Assets/Scripts/UI/CutsceneManager.cs
+++ b/Assets/Scripts/UI/CutsceneManager.cs
@@ -133,15 +133,18 @@ public class CutsceneManager : MonoBehaviour
                 _introStoryPanel.SetActive(true);
                 GameObject.Find("Player").GetComponent<Cinematic>().cinematic = "Abe Rises";
                 GameObject.Find("Player").GetComponent<Cinematic>().enabled = true;
+                GameObject.Find("Player").GetComponent<PlayerHealth>().RefillForCutscene();
                 break;
             case Cutscenes.MID:
                 cutsceneActive = true;
                 _midStoryPanel.SetActive(true);
+                GameObject.Find("Player").GetComponent<PlayerHealth>().RefillForCutscene();
                 break;
             case Cutscenes.END:
                 cutsceneActive = true;
                 _endStoryPanel.SetActive(true);
                 GameObject.Find("Player").GetComponent<Player>().PlayEnding();
+                GameObject.Find("Player").GetComponent<PlayerHealth>().RefillForCutscene();
                 break;
             case Cutscenes.NULL:
                 cutsceneActive = false;


### PR DESCRIPTION
A cutscene will now trigger a function that refills the player's health and DT to make sure he doesn't die mid-cutscene
